### PR TITLE
build: Update compile SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,10 +19,10 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('UsbSerialportForAndroid_compileSdkVersion', 30)
+    compileSdkVersion safeExtGet('UsbSerialportForAndroid_compileSdkVersion', 34)
     defaultConfig {
         minSdkVersion safeExtGet('UsbSerialportForAndroid_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('UsbSerialportForAndroid_targetSdkVersion', 30)
+        targetSdkVersion safeExtGet('UsbSerialportForAndroid_targetSdkVersion', 34)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
I keep getting 'Android resource linking failed. <project_root>/node_modules/react-native-usb-serialport-for-android/build/intermediates/merged_res/release/values/values.xml:2721: AAPT: error: resource android/lStar not found.' error in release builds. Updating target and compile SDK versions should resolve this issue.